### PR TITLE
refactor: トランザクション結果の検証を共通化

### DIFF
--- a/src/lib/validateTransaction.ts
+++ b/src/lib/validateTransaction.ts
@@ -1,0 +1,19 @@
+import type { TxResponse } from 'xrpl';
+
+/**
+ * トランザクション結果を検証し、tesSUCCESS以外の場合はエラーをスローする
+ *
+ * @param result - トランザクション結果
+ * @throws {Error} トランザクションが失敗した場合
+ */
+export function validateTransactionResult(result: TxResponse): void {
+  const txResult =
+    typeof result.result.meta === 'object' &&
+    'TransactionResult' in result.result.meta
+      ? result.result.meta.TransactionResult
+      : 'unknown';
+
+  if (txResult !== 'tesSUCCESS') {
+    throw new Error(`Transaction failed: ${txResult}`);
+  }
+}

--- a/src/xrpl/Credentials/credentialAccept.ts
+++ b/src/xrpl/Credentials/credentialAccept.ts
@@ -7,6 +7,7 @@ import {
 import { env } from '../../config/env';
 import { getNetworkUrl } from '../../config/network';
 import { logExplorerUrl } from '../../lib/logger';
+import { validateTransactionResult } from '../../lib/validateTransaction';
 
 export async function credentialAccept(): Promise<boolean> {
   // ネットワーク設定
@@ -38,16 +39,8 @@ export async function credentialAccept(): Promise<boolean> {
     // トランザクションを送信して結果を待機
     const result = await client.submitAndWait(signed.tx_blob);
 
-    // トランザクション結果を確認
-    const txResult =
-      typeof result.result.meta === 'object' &&
-      'TransactionResult' in result.result.meta
-        ? result.result.meta.TransactionResult
-        : 'unknown';
-
-    if (txResult !== 'tesSUCCESS') {
-      throw new Error(`Transaction failed: ${txResult}`);
-    }
+    // トランザクション結果を確認（tesSUCCESS以外はエラーをスロー）
+    validateTransactionResult(result);
 
     console.log('✅ Credential受け入れが完了しました');
 

--- a/src/xrpl/Credentials/credentialCreate.ts
+++ b/src/xrpl/Credentials/credentialCreate.ts
@@ -8,6 +8,7 @@ import {
 import { env } from '../../config/env';
 import { getNetworkUrl } from '../../config/network';
 import { logExplorerUrl } from '../../lib/logger';
+import { validateTransactionResult } from '../../lib/validateTransaction';
 
 export async function credentialCreate(): Promise<boolean> {
   // ネットワーク設定
@@ -43,16 +44,8 @@ export async function credentialCreate(): Promise<boolean> {
     // トランザクションを送信して結果を待機
     const result = await client.submitAndWait(signed.tx_blob);
 
-    // トランザクション結果を確認
-    const txResult =
-      typeof result.result.meta === 'object' &&
-      'TransactionResult' in result.result.meta
-        ? result.result.meta.TransactionResult
-        : 'unknown';
-
-    if (txResult !== 'tesSUCCESS') {
-      throw new Error(`Transaction failed: ${txResult}`);
-    }
+    // トランザクション結果を確認（tesSUCCESS以外はエラーをスロー）
+    validateTransactionResult(result);
 
     console.log('✅ Credential作成が完了しました');
 

--- a/src/xrpl/Credentials/credentialDelete.ts
+++ b/src/xrpl/Credentials/credentialDelete.ts
@@ -7,6 +7,7 @@ import {
 import { env } from '../../config/env';
 import { getNetworkUrl } from '../../config/network';
 import { logExplorerUrl } from '../../lib/logger';
+import { validateTransactionResult } from '../../lib/validateTransaction';
 
 export async function credentialDelete(): Promise<boolean> {
   // ネットワーク設定
@@ -47,16 +48,8 @@ export async function credentialDelete(): Promise<boolean> {
     // トランザクションを送信して結果を待機
     const result = await client.submitAndWait(signed.tx_blob);
 
-    // トランザクション結果を確認
-    const txResult =
-      typeof result.result.meta === 'object' &&
-      'TransactionResult' in result.result.meta
-        ? result.result.meta.TransactionResult
-        : 'unknown';
-
-    if (txResult !== 'tesSUCCESS') {
-      throw new Error(`Transaction failed: ${txResult}`);
-    }
+    // トランザクション結果を確認（tesSUCCESS以外はエラーをスロー）
+    validateTransactionResult(result);
 
     console.log('✅ Credential削除が完了しました');
 

--- a/src/xrpl/Payment/sendIOU.ts
+++ b/src/xrpl/Payment/sendIOU.ts
@@ -2,6 +2,7 @@ import { Client, Wallet, type Payment } from 'xrpl';
 import { env } from '../../config/env';
 import { getNetworkUrl } from '../../config/network';
 import { logExplorerUrl } from '../../lib/logger';
+import { validateTransactionResult } from '../../lib/validateTransaction';
 
 export async function sendIOU(): Promise<boolean> {
   // ネットワーク設定
@@ -36,6 +37,10 @@ export async function sendIOU(): Promise<boolean> {
 
     // トランザクションを送信して結果を待機
     const result = await client.submitAndWait(signed.tx_blob);
+
+    // トランザクション結果を確認（tesSUCCESS以外はエラーをスロー）
+    validateTransactionResult(result);
+
     console.log('✅ IOU送金処理が完了しました');
 
     // 結果の表示

--- a/src/xrpl/TrustSet/trustSet.ts
+++ b/src/xrpl/TrustSet/trustSet.ts
@@ -2,6 +2,7 @@ import { Client, Wallet, type TrustSet } from 'xrpl';
 import { env } from '../../config/env';
 import { getNetworkUrl } from '../../config/network';
 import { logExplorerUrl } from '../../lib/logger';
+import { validateTransactionResult } from '../../lib/validateTransaction';
 
 export async function trustSet(): Promise<boolean> {
   // ネットワーク設定
@@ -35,6 +36,10 @@ export async function trustSet(): Promise<boolean> {
 
     // トランザクションを送信して結果を待機
     const result = await client.submitAndWait(signed.tx_blob);
+
+    // トランザクション結果を確認（tesSUCCESS以外はエラーをスロー）
+    validateTransactionResult(result);
+
     console.log('✅ TrustLine設定が完了しました');
 
     // 結果の表示


### PR DESCRIPTION
- libにvalidateTransactionResult関数を新規作成
- 全トランザクションでtesSUCCESS以外はエラーをThrowし、ログのヒントが表示されるように修正
- Payment/TrustSetのエラーハンドリングを改善
- コードの重複を削減し保守性を向上