### PR TITLE
feat: MPTを追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 NODE_ENV="devnet" # mainnet / testnet / devnet
 
 IOU_CURRENCY="ABC"
+MPT_ISSUANCE_ID=""
 
 ISUEER_SEED=""
 USER_SEED=""

--- a/README.md
+++ b/README.md
@@ -35,10 +35,13 @@ npx tsx src/xrpl/Payment/sendIOU.ts
 # 6) Credential作成
 npx tsx src/xrpl/Credentials/credentialCreate.ts
 
-# 7) NFT発行
+# 7) MPToken発行
+npx tsx src/xrpl/MPTokens/mptokenIssuanceCreate.ts
+
+# 8) NFT発行
 npx tsx src/xrpl/NFToken/nftokenMint.ts
 
-# 8) Batchトランザクション（複数トランザクションを一括実行）
+# 9) Batchトランザクション（複数トランザクションを一括実行）
 npx tsx src/xrpl/Batch/batchAllOrNothing.ts
 ```
 
@@ -72,6 +75,14 @@ src/
     │   ├── credentialDelete.ts
     │   └── README.md
     │
+    ├── MPTokens/     # Multi-Purpose Tokens
+    │   ├── mptokenIssuanceCreate.ts
+    │   ├── mptokenAuthorize.ts
+    │   ├── mptokenPayment.ts
+    │   ├── mptokenClawback.ts
+    │   ├── mptokenIssuanceDestroy.ts
+    │   └── README.md
+    │
     ├── NFToken/      # NFT管理
     │   ├── nftokenMint.ts
     │   ├── nftokenMintOffer.ts
@@ -96,6 +107,7 @@ src/
 
 - [Batch](src/xrpl/Batch/README.md) - バッチトランザクション（複数トランザクションの一括実行）
 - [Credentials](src/xrpl/Credentials/README.md) - 検証可能な資格情報管理機能
+- [MPTokens](src/xrpl/MPTokens/README.md) - Multi-Purpose Tokens（MPトークン）発行・管理機能
 - [NFToken](src/xrpl/NFToken/README.md) - NFT発行・管理機能
 - [Payment](src/xrpl/Payment/README.md) - XRP/IOU送金機能
 - [TrustSet](src/xrpl/TrustSet/README.md) - 信頼線設定機能

--- a/biome.json
+++ b/biome.json
@@ -17,7 +17,10 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "complexity": {
+        "useLiteralKeys": "off"
+      }
     }
   },
   "javascript": {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -10,6 +10,9 @@ const envSchema = z.object({
   IOU_CURRENCY: z.string().min(1, {
     message: 'IOU_CURRENCYが不正です',
   }),
+  MPT_ISSUANCE_ID: z.string().min(1, {
+    message: 'MPT_ISSUANCE_IDが不正です',
+  }),
   ISUEER_SEED: z.string().min(1, {
     message: 'ISUEER_SEEDが不正です',
   }),

--- a/src/lib/getBatchTxStatus.ts
+++ b/src/lib/getBatchTxStatus.ts
@@ -48,7 +48,7 @@ export async function getBatchTxStatus(
           successful: false,
           status: 'unknown',
         };
-      } catch (error) {
+      } catch (_error) {
         return {
           hash: tx.hash,
           index: tx.index,

--- a/src/xrpl/MPTokens/README.md
+++ b/src/xrpl/MPTokens/README.md
@@ -1,0 +1,222 @@
+# MPTokens (Multi-Purpose Tokens)
+
+XRPLの新しいトークン標準であるMPT（Multi-Purpose Tokens）を使用するスクリプト集です。
+MPTは、柔軟で効率的なトークン発行・管理を可能にする機能です。
+
+## 🎯 MPTの特徴
+
+- **効率的な設計**: 既存のトークン標準よりも効率的なストレージとトランザクション
+- **柔軟な設定**: 最大供給量、転送手数料、メタデータなどのカスタマイズが可能
+- **認可制御**: ホルダーごとの認可・非認可を管理可能
+- **Clawback機能**: 必要に応じてトークンを取り戻すことが可能
+
+## 📂 シナリオ実行コマンドと説明
+
+### 1. MPTの発行 (MPTokenIssuanceCreate)
+```bash
+npx tsx src/xrpl/MPTokens/mptokenIssuanceCreate.ts
+```
+新しいMPTを発行します。トークンのメタデータ、最大供給量、転送手数料などを設定できます。
+
+**主要パラメータ:**
+- `AssetScale`: トークンの小数点以下の桁数（0-19）
+- `MaximumAmount`: 最大供給量（オプション）
+- `TransferFee`: 転送手数料（0-50000、つまり0-50%）
+- `MPTokenMetadata`: トークンのメタデータ（オプション、XLS-89d標準推奨）
+
+**MPTokenMetadata（XLS-89d標準 - 国債の例）:**
+現在、XLS-89dでメタデータ構造の標準化が検討されています。この標準に準拠することで、ExplorerやIndexerでの検出性が向上します。
+
+```json
+{
+  "ticker": "JGB10Y",                                  // 必須: ティッカーシンボル（10年国債）
+  "name": "Japan Government Bond Token",              // 必須: トークンの表示名
+  "desc": "A yield-bearing token backed by 10-year Japanese Government Bonds with fixed interest payments.", // オプション: トークンの説明
+  "icon": "https://example.org/jgb-icon.png",         // 必須: アイコンURL（HTTPS）
+  "asset_class": "rwa",                               // 必須: Real World Assets
+  "asset_subclass": "treasury",                       // asset_class='rwa'の場合は必須
+  "issuer_name": "Japan Treasury Co.",                // 必須: 発行者名
+  "urls": [                                           // オプション: 関連URLリスト
+    {
+      "url": "https://japan-treasury.co/jgb10y",
+      "type": "website",
+      "title": "Product Page"
+    },
+    {
+      "url": "https://japan-treasury.co/docs",
+      "type": "docs",
+      "title": "Bond Token Documentation"
+    }
+  ],
+  "additional_info": {                                // オプション: 追加情報（金利、満期日等）
+    "interest_rate": "0.50%",
+    "interest_type": "fixed",
+    "yield_source": "Japanese Government Bonds",
+    "maturity_date": "2034-03-20",
+    "bond_code": "JGB10Y-2034",
+    "face_value": "1000000",
+    "payment_frequency": "semi-annual"
+  }
+}
+```
+
+**asset_class の値:**
+- `rwa`: Real World Assets（現実資産）- この場合asset_subclassが必須
+- `memes`: ミームトークン
+- `wrapped`: ラップされたトークン
+- `gaming`: ゲーム関連トークン
+- `defi`: DeFi関連トークン
+- `other`: その他
+
+**asset_subclass の値（asset_class='rwa'の場合）:**
+- `treasury`: 国債
+- `corporate_bond`: 社債
+- `real_estate`: 不動産
+- `commodity`: 商品
+- `equity`: 株式
+- その他のRWA関連サブクラス
+
+### 2. 保有者の認可 (MPTokenAuthorize)
+
+MPTの認可は、ユーザーと発行者の2つのステップで構成されます。
+
+#### 2-1. ユーザー自身が保有を承認
+```bash
+npx tsx src/xrpl/MPTokens/mptokenAuthorizeByUser.ts
+```
+ユーザー自身がMPTの保有を承認します。これは必須のステップです。
+
+**パラメータ:**
+- `MPTokenIssuanceID`: 認可するMPTのID（環境変数から取得）
+
+#### 2-2. 発行者がユーザーを認可
+```bash
+npx tsx src/xrpl/MPTokens/mptokenAuthorizeByIssuer.ts
+```
+発行者がユーザーを認可します。**mptokenIssuanceCreate.ts で `tfMPTRequireAuth` フラグを有効にした場合のみ必要です。**
+
+**パラメータ:**
+- `MPTokenIssuanceID`: 認可するMPTのID（環境変数から取得）
+- `Holder`: 認可されるアカウント（USER_SEEDから取得）
+
+**共通フラグ:**
+- `Flags`: フラグ（オプション）
+  - `tfMPTUnauthorize`: 認可を取り消す場合に使用
+
+**認可フローの注意:**
+- ユーザー承認（2-1）は常に必要
+- 発行者認可（2-2）は`tfMPTRequireAuth`フラグが有効な場合のみ必要
+- 両方完了してから送金が可能になります
+
+### 3. MPTの送金 (Payment)
+```bash
+npx tsx src/xrpl/MPTokens/mptokenPayment.ts
+```
+MPTを他のアカウントに送金します。受信者は事前に認可が必要です。
+
+**パラメータ:**
+- `MPTokenIssuanceID`: MPTのID（環境変数から取得）
+- `Amount`: 送金量
+  ```typescript
+  {
+    mpt_issuance_id: "MPT_ISSUANCE_ID",
+    value: "100" // 送金量
+  }
+  ```
+
+**注意事項:**
+- 受信者は事前に`mptokenAuthorizeByUser.ts`で保有を承認している必要があります
+- `tfMPTRequireAuth`が有効な場合、受信者は`mptokenAuthorizeByIssuer.ts`での認可も必要です
+- 送金後、受信者のMPT残高が表示されます
+
+### 4. MPTの取り戻し (Clawback)
+```bash
+npx tsx src/xrpl/MPTokens/mptokenClawback.ts
+```
+発行者が保有者からMPTを取り戻します。**mptokenIssuanceCreate.ts で `tfMPTCanClawback` フラグを有効にした場合のみ実行可能です。**
+
+**パラメータ:**
+- `MPTokenIssuanceID`: MPTのID（環境変数から取得）
+- `Holder`: MPTを取り戻す対象のアカウント（USER_SEEDから取得）
+- `Amount`: 取り戻す数量
+  ```typescript
+  {
+    mpt_issuance_id: "MPTID",
+    value: "10" // 取り戻す量
+  }
+  ```
+
+**機能:**
+- Clawback前後の保有者残高を表示
+- 指定したMPTokenIssuanceIDに対する残高のみを表示
+
+### 5. MPTの破棄 (MPTokenIssuanceDestroy)
+```bash
+npx tsx src/xrpl/MPTokens/mptokenIssuanceDestroy.ts
+```
+発行されたMPTを完全に破棄します。すべての保有者が保有していないことが前提です。
+
+**パラメータ:**
+- `MPTokenIssuanceID`: 破棄するMPTのID（環境変数から取得）
+
+**前提条件:**
+- すべての保有者がトークンを保有していない状態（OutstandingAmount = 0）
+- 発行者のみが実行可能
+
+**機能:**
+- 破棄前のMPTokenIssuance情報を確認
+- OutstandingAmountが0でない場合は警告を表示
+
+## ✅ 予想される結果
+
+**成功時:**
+- `mptokenIssuanceCreate.ts` → MPTのIDが発行され、レジャーに記録される
+- `mptokenAuthorizeByUser.ts` → ユーザーがMPTの保有を承認
+- `mptokenAuthorizeByIssuer.ts` → 発行者がユーザーを認可
+- `mptokenPayment.ts` → 受信者にMPTが送金される
+- `mptokenClawback.ts` → 指定した保有者からMPTが取り戻される
+- `mptokenIssuanceDestroy.ts` → MPTが完全に破棄される
+
+**失敗時:**
+- 認可されていないユーザーへの送金 → `tecNO_AUTH`エラー
+- Clawbackフラグなしでの取り戻し → `tecNO_PERMISSION`エラー
+- 保有者が存在する状態での破棄 → `tecHAS_OBLIGATIONS`エラー
+- `.env`設定不足 → 実行不可
+
+## 🔍 主要なフラグ
+
+### MPTokenIssuanceCreateで使用できる主なフラグ:
+- `tfMPTCanLock`: トークンをロック可能にする
+- `tfMPTRequireAuth`: 保有者の認可を必須にする（**有効にすると`mptokenAuthorizeByIssuer.ts`での発行者認可が必要**）
+- `tfMPTCanESDT`: ESDTトークンとして使用可能にする
+- `tfMPTCanTrade`: DEXでの取引機能を有効にする ※将来的にDEXでのMPTのTrade機能が実装された場合に使用可能になります
+- `tfMPTCanTransfer`: 第三者間の転送機能を有効にする（TransferFeeを設定する場合は必須）
+- `tfMPTCanClawback`: Clawback機能を有効にする（**有効にすると`mptokenClawback.ts`でトークンの取り戻しが可能**）
+- `tfMPTCanEscrow`: Escrow機能を有効にする ※TokenEscrow Amendmentが有効なネットワークでのみ動作します
+
+### MPTokenAuthorizeで使用できる主なフラグ:
+- `tfMPTUnauthorize`: 認可を取り消す場合に使用
+
+## 🔗 参考文献
+
+- [XRPL - MPTokenIssuanceCreate](https://xrpl.org/ja/docs/references/protocol/transactions/types/mptokenissuancecreate/)
+- [XRPL - MPTokenAuthorize](https://xrpl.org/ja/docs/references/protocol/transactions/types/mptokenauthorize/)
+- [XRPL - Clawback](https://xrpl.org/ja/docs/references/protocol/transactions/types/clawback/)
+- [XLS-89d Standard](https://github.com/XRPLF/XRPL-Standards/tree/master/XLS-0089-multi-purpose-token-metadata-schema)
+
+## 📝 注意事項
+
+1. **Amendment要件**: MPTokensV1 Amendmentが有効なネットワークでのみ動作します
+2. **環境変数**: すべてのスクリプトは`.env`ファイルから設定を読み込みます
+   - `ISUEER_SEED`: 発行者のシークレット
+   - `USER_SEED`: ユーザーのシークレット
+   - `MPT_ISSUANCE_ID`: MPTokenIssuanceID（`mptokenIssuanceCreate.ts`実行後に設定）
+3. **認可フロー**: 
+   - ユーザー承認（`mptokenAuthorizeByUser.ts`）は常に必要
+   - `tfMPTRequireAuth`フラグを設定した場合、発行者認可（`mptokenAuthorizeByIssuer.ts`）も必要
+4. **Clawback**: `tfMPTCanClawback`フラグを設定すると、発行者がMPTを取り戻せます
+5. **破棄条件**: MPTを破棄するには、すべての保有者が保有していない状態（OutstandingAmount = 0）が必要です
+6. **不可逆的な操作**: 一度設定したフラグは変更できないため、慎重に設定してください
+7. **メタデータ標準**: XLS-89d標準に準拠することで、ExplorerやIndexerでの検出性が向上します
+8. **残高表示**: 送金・Clawback実行時は、指定したMPTokenIssuanceIDに対する残高のみを表示します
+

--- a/src/xrpl/MPTokens/mptokenAuthorizeByIssuer.ts
+++ b/src/xrpl/MPTokens/mptokenAuthorizeByIssuer.ts
@@ -1,0 +1,108 @@
+import { Client, type MPTokenAuthorize, Wallet } from 'xrpl';
+import { env } from '../../config/env';
+import { getNetworkUrl } from '../../config/network';
+import { logExplorerUrl } from '../../lib/logger';
+import { validateTransactionResult } from '../../lib/validateTransaction';
+
+// 発行者がユーザーを認可する関数
+export async function mptokenAuthorizeByIssuer(): Promise<boolean> {
+  // ネットワーク設定
+  const network = getNetworkUrl();
+  const client = new Client(network.ws);
+
+  try {
+    // ウォレット作成
+    const issuer = Wallet.fromSeed(env.ISUEER_SEED);
+    const user = Wallet.fromSeed(env.USER_SEED);
+
+    // XRPLネットワークに接続
+    await client.connect();
+
+    console.log('🔐 発行者がユーザーを認可します...');
+    console.log(`発行者アドレス: ${issuer.address}`);
+    console.log(`ユーザーアドレス: ${user.address}`);
+
+    // 環境変数からMPTokenIssuanceIDを取得
+    const mptIssuanceID = env.MPT_ISSUANCE_ID || '';
+
+    if (!mptIssuanceID) {
+      console.error('\n❌ MPTokenIssuanceIDが設定されていません');
+      console.error(
+        '💡 ヒント: mptokenIssuanceCreate.ts を実行して取得したMPTokenIssuanceIDを設定してください',
+      );
+      return false;
+    }
+
+    // 発行者がユーザーを認可する
+    // ※ mptokenIssuanceCreate.ts で tfMPTRequireAuth フラグを有効にした場合、
+    //    ユーザーがトークンを受け取る前に、発行者による認可が必要です
+    const issuerAuthTx: MPTokenAuthorize = {
+      TransactionType: 'MPTokenAuthorize',
+      Account: issuer.address, // 発行者アドレス
+      MPTokenIssuanceID: mptIssuanceID, // MPトークンID
+      Holder: user.address, // 認可するユーザーアドレス
+      // Flags: MPTokenAuthorizeFlags.tfMPTUnauthorize, // 認可を取り消す場合に使用
+    };
+
+    // トランザクションの自動入力（手数料、シーケンス番号など）
+    const issuerPrepared = await client.autofill(issuerAuthTx);
+
+    // トランザクションに署名
+    const issuerSigned = issuer.sign(issuerPrepared);
+
+    // トランザクションを送信して結果を待機
+    const issuerResult = await client.submitAndWait(issuerSigned.tx_blob);
+
+    // トランザクション結果を確認（tesSUCCESS以外はエラーをスロー）
+    validateTransactionResult(issuerResult);
+
+    console.log('\n✅ 発行者による認可が完了しました');
+
+    console.log('\n📊 認可情報:');
+    console.log(`  - MPTokenIssuanceID: ${mptIssuanceID}`);
+    console.log(`  - 保有者: ${user.address}`);
+    console.log(`  - 発行者: ${issuer.address}`);
+
+    // エクスプローラーで確認できるURLを表示
+    logExplorerUrl(issuerResult.result.hash);
+
+    return true;
+  } catch (error) {
+    console.error('❌ エラーが発生しました:', error);
+
+    // MPTokenAuthorize特有のエラーメッセージの説明
+    if (error instanceof Error) {
+      if (error.message.includes('temDISABLED')) {
+        console.error('💡 ヒント: MPTokensV1 Amendmentが有効ではありません');
+      } else if (error.message.includes('tecNO_ENTRY')) {
+        console.error('💡 ヒント: 指定されたMPTokenIssuanceIDが存在しません');
+      } else if (error.message.includes('tecNO_PERMISSION')) {
+        console.error(
+          '💡 ヒント: 認可する権限がありません（発行者のみが認可できます）',
+        );
+      } else if (error.message.includes('tecDUPLICATE')) {
+        console.error('💡 ヒント: 既に認可されています');
+      } else if (error.message.includes('tecINSUFFICIENT_RESERVE')) {
+        console.error(
+          '💡 ヒント: トランザクション実行後にアカウントの準備金要件を満たせません',
+        );
+      } else if (error.message.includes('temMALFORMED')) {
+        console.error('💡 ヒント: トランザクションが正しく指定されていません');
+      }
+    }
+
+    return false;
+  } finally {
+    // 接続を終了
+    await client.disconnect();
+  }
+}
+
+// スクリプトが直接実行された場合の処理
+if (import.meta.url === `file://${process.argv[1]}`) {
+  mptokenAuthorizeByIssuer().then((success) => {
+    if (!success) {
+      process.exit(1);
+    }
+  });
+}

--- a/src/xrpl/MPTokens/mptokenAuthorizeByUser.ts
+++ b/src/xrpl/MPTokens/mptokenAuthorizeByUser.ts
@@ -1,0 +1,98 @@
+import { Client, type MPTokenAuthorize, Wallet } from 'xrpl';
+import { env } from '../../config/env';
+import { getNetworkUrl } from '../../config/network';
+import { logExplorerUrl } from '../../lib/logger';
+import { validateTransactionResult } from '../../lib/validateTransaction';
+
+// ユーザー自身がMPTokenの保有を承認する関数
+export async function mptokenAuthorizeByUser(): Promise<boolean> {
+  // ネットワーク設定
+  const network = getNetworkUrl();
+  const client = new Client(network.ws);
+
+  try {
+    // ウォレット作成
+    const user = Wallet.fromSeed(env.USER_SEED);
+
+    // XRPLネットワークに接続
+    await client.connect();
+
+    console.log('🔐 ユーザーがMPTokenの保有を承認します...');
+    console.log(`ユーザーアドレス: ${user.address}`);
+
+    // 環境変数からMPTokenIssuanceIDを取得
+    const mptIssuanceID = env.MPT_ISSUANCE_ID || '';
+
+    if (!mptIssuanceID) {
+      console.error('\n❌ MPTokenIssuanceIDが設定されていません');
+      console.error(
+        '💡 ヒント: mptokenIssuanceCreate.ts を実行して取得したMPTokenIssuanceIDを設定してください',
+      );
+      return false;
+    }
+
+    // ユーザー自身が保有を承認する
+    const userAuthTx: MPTokenAuthorize = {
+      TransactionType: 'MPTokenAuthorize',
+      Account: user.address, // 保有者アドレス
+      MPTokenIssuanceID: mptIssuanceID, // MPトークンID
+      // Flags: MPTokenAuthorizeFlags.tfMPTUnauthorize, // 認可を取り消す場合に使用
+    };
+
+    // トランザクションの自動入力（手数料、シーケンス番号など）
+    const userPrepared = await client.autofill(userAuthTx);
+
+    // トランザクションに署名
+    const userSigned = user.sign(userPrepared);
+
+    // トランザクションを送信して結果を待機
+    const userResult = await client.submitAndWait(userSigned.tx_blob);
+
+    // トランザクション結果を確認（tesSUCCESS以外はエラーをスロー）
+    validateTransactionResult(userResult);
+
+    console.log('\n✅ ユーザーの保有承認が完了しました');
+
+    console.log('\n📊 承認情報:');
+    console.log(`  - MPTokenIssuanceID: ${mptIssuanceID}`);
+    console.log(`  - 保有者: ${user.address}`);
+
+    // エクスプローラーで確認できるURLを表示
+    logExplorerUrl(userResult.result.hash);
+
+    return true;
+  } catch (error) {
+    console.error('❌ エラーが発生しました:', error);
+
+    // MPTokenAuthorize特有のエラーメッセージの説明
+    if (error instanceof Error) {
+      if (error.message.includes('temDISABLED')) {
+        console.error('💡 ヒント: MPTokensV1 Amendmentが有効ではありません');
+      } else if (error.message.includes('tecNO_ENTRY')) {
+        console.error('💡 ヒント: 指定されたMPTokenIssuanceIDが存在しません');
+      } else if (error.message.includes('tecDUPLICATE')) {
+        console.error('💡 ヒント: 既に承認されています');
+      } else if (error.message.includes('tecINSUFFICIENT_RESERVE')) {
+        console.error(
+          '💡 ヒント: トランザクション実行後にアカウントの準備金要件を満たせません',
+        );
+      } else if (error.message.includes('temMALFORMED')) {
+        console.error('💡 ヒント: トランザクションが正しく指定されていません');
+      }
+    }
+
+    return false;
+  } finally {
+    // 接続を終了
+    await client.disconnect();
+  }
+}
+
+// スクリプトが直接実行された場合の処理
+if (import.meta.url === `file://${process.argv[1]}`) {
+  mptokenAuthorizeByUser().then((success) => {
+    if (!success) {
+      process.exit(1);
+    }
+  });
+}

--- a/src/xrpl/MPTokens/mptokenClawback.ts
+++ b/src/xrpl/MPTokens/mptokenClawback.ts
@@ -1,0 +1,178 @@
+import { type Clawback, Client, Wallet } from 'xrpl';
+import { env } from '../../config/env';
+import { getNetworkUrl } from '../../config/network';
+import { logExplorerUrl } from '../../lib/logger';
+import { validateTransactionResult } from '../../lib/validateTransaction';
+
+export async function mptokenClawback(): Promise<boolean> {
+  // ネットワーク設定
+  const network = getNetworkUrl();
+  const client = new Client(network.ws);
+
+  try {
+    // ウォレット作成
+    const issuer = Wallet.fromSeed(env.ISUEER_SEED);
+    const user = Wallet.fromSeed(env.USER_SEED);
+
+    // XRPLネットワークに接続
+    await client.connect();
+
+    console.log('🔙 MPTokenをClawback（取り戻し）します...');
+    console.log(`発行者アドレス: ${issuer.address}`);
+    console.log(`保有者アドレス: ${user.address}`);
+
+    // 環境変数からMPTokenIssuanceIDを取得
+    const mptIssuanceID = env.MPT_ISSUANCE_ID || '';
+
+    if (!mptIssuanceID) {
+      console.error('\n❌ MPTokenIssuanceIDが設定されていません');
+      console.error(
+        '💡 ヒント: mptokenIssuanceCreate.ts を実行して取得したMPTokenIssuanceIDを設定してください',
+      );
+      return false;
+    }
+
+    // 保有者の残高を確認
+    console.log('\n💰 Clawback前の保有者残高を確認...');
+    try {
+      const holderBalance = await client.request({
+        command: 'account_objects',
+        account: user.address,
+        ledger_index: 'validated',
+      });
+      if ('account_objects' in holderBalance.result) {
+        const mptBalances = holderBalance.result.account_objects.filter(
+          (obj) => {
+            const ledgerObj = obj as {
+              LedgerEntryType: string;
+              MPTokenIssuanceID?: string;
+            };
+            return (
+              ledgerObj.LedgerEntryType === 'MPToken' &&
+              ledgerObj.MPTokenIssuanceID === mptIssuanceID
+            );
+          },
+        );
+        if (mptBalances.length > 0) {
+          const mptBalance = mptBalances[0] as unknown as {
+            MPTokenIssuanceID: string;
+            MPTAmount: string;
+          };
+          console.log(`  - MPTokenIssuanceID: ${mptBalance.MPTokenIssuanceID}`);
+          console.log(`    残高: ${mptBalance.MPTAmount}`);
+        } else {
+          console.log('  - 該当するMPToken残高がありません');
+        }
+      }
+    } catch (balanceError) {
+      console.log('⚠️  残高取得に失敗しました:', balanceError);
+    }
+
+    // Clawbackトランザクションの準備
+    const tx: Clawback = {
+      TransactionType: 'Clawback',
+      Account: issuer.address, // 発行者アドレス（トークンを取り戻す側）
+      Holder: user.address, // 保有者アドレス（トークンを取り戻される側）
+      Amount: {
+        mpt_issuance_id: mptIssuanceID, // MPT Issuance ID
+        value: '100', // 取り戻す量
+      },
+    };
+
+    // トランザクションの自動入力（手数料、シーケンス番号など）
+    const prepared = await client.autofill(tx);
+
+    // トランザクションに署名
+    const signed = issuer.sign(prepared);
+
+    // トランザクションを送信して結果を待機
+    const result = await client.submitAndWait(signed.tx_blob);
+
+    // トランザクション結果を確認（tesSUCCESS以外はエラーをスロー）
+    validateTransactionResult(result);
+
+    console.log('\n✅ Clawbackが完了しました');
+
+    console.log('\n📊 Clawback情報:');
+    console.log(`  - MPTokenIssuanceID: ${mptIssuanceID}`);
+    console.log(`  - 取り戻し量: ${tx.Amount.value}`);
+
+    // Clawback後の残高を確認
+    console.log('\n💰 Clawback後の保有者残高:');
+    try {
+      const holderBalanceAfter = await client.request({
+        command: 'account_objects',
+        account: user.address,
+        ledger_index: 'validated',
+      });
+      if ('account_objects' in holderBalanceAfter.result) {
+        const mptBalances = holderBalanceAfter.result.account_objects.filter(
+          (obj) => {
+            const ledgerObj = obj as {
+              LedgerEntryType: string;
+              MPTokenIssuanceID?: string;
+            };
+            return (
+              ledgerObj.LedgerEntryType === 'MPToken' &&
+              ledgerObj.MPTokenIssuanceID === mptIssuanceID
+            );
+          },
+        );
+        if (mptBalances.length > 0) {
+          const mptBalance = mptBalances[0] as unknown as {
+            MPTokenIssuanceID: string;
+            MPTAmount: string;
+          };
+          console.log(`  - MPTokenIssuanceID: ${mptBalance.MPTokenIssuanceID}`);
+          console.log(`    残高: ${mptBalance.MPTAmount}`);
+        } else {
+          console.log('  - 該当するMPToken残高がありません');
+        }
+      }
+    } catch (balanceError) {
+      console.log('⚠️  残高取得に失敗しました:', balanceError);
+    }
+
+    // エクスプローラーで確認できるURLを表示
+    logExplorerUrl(result.result.hash);
+
+    return true;
+  } catch (error) {
+    console.error('❌ エラーが発生しました:', error);
+
+    // Clawback特有のエラーメッセージの説明
+    if (error instanceof Error) {
+      if (error.message.includes('tecNO_PERMISSION')) {
+        console.error(
+          '💡 ヒント: Clawback権限がありません（発行者のみが実行可能、かつtfMPTCanClawbackフラグが必要です）',
+        );
+      } else if (error.message.includes('tecNO_ENTRY')) {
+        console.error('💡 ヒント: 指定されたMPTokenIssuanceIDが存在しません');
+      } else if (error.message.includes('tecINSUFFICIENT_FUNDS')) {
+        console.error('💡 ヒント: 保有者の残高が不足しています');
+      } else if (error.message.includes('temMALFORMED')) {
+        console.error('💡 ヒント: トランザクションが正しく指定されていません');
+      } else if (error.message.includes('temDISABLED')) {
+        console.error('💡 ヒント: Clawback Amendmentが有効ではありません');
+      } else if (error.message.includes('tecINSUFFICIENT_RESERVE')) {
+        console.error(
+          '💡 ヒント: トランザクション実行後にアカウントの準備金要件を満たせません',
+        );
+      }
+    }
+
+    return false;
+  } finally {
+    // 接続を終了
+    await client.disconnect();
+  }
+}
+
+// スクリプトが直接実行された場合の処理
+if (import.meta.url === `file://${process.argv[1]}`) {
+  mptokenClawback().then((success) => {
+    if (!success) {
+      process.exit(1);
+    }
+  });
+}

--- a/src/xrpl/MPTokens/mptokenIssuanceCreate.ts
+++ b/src/xrpl/MPTokens/mptokenIssuanceCreate.ts
@@ -1,0 +1,180 @@
+import {
+  Client,
+  convertStringToHex,
+  type MPTokenIssuanceCreate,
+  MPTokenIssuanceCreateFlags,
+  Wallet,
+} from 'xrpl';
+import { env } from '../../config/env';
+import { getNetworkUrl } from '../../config/network';
+import { logExplorerUrl } from '../../lib/logger';
+import { validateTransactionResult } from '../../lib/validateTransaction';
+
+export async function mptokenIssuanceCreate(): Promise<boolean> {
+  // ネットワーク設定
+  const network = getNetworkUrl();
+  const client = new Client(network.ws);
+
+  try {
+    // ウォレット作成（発行者）
+    const issuer = Wallet.fromSeed(env.ISUEER_SEED);
+
+    // XRPLネットワークに接続
+    await client.connect();
+
+    console.log('🪙 MPTokenを発行します...');
+    console.log(`発行者アドレス: ${issuer.address}`);
+
+    // MPTのメタデータ（XLS-89d標準に準拠 - 国債を想定）
+    const metadata = JSON.stringify({
+      ticker: 'JGB10Y', // 必須: ティッカーシンボル（10年国債）
+      name: 'Japan Government Bond Token', // 必須: トークンの表示名
+      desc: 'A yield-bearing token backed by 10-year Japanese Government Bonds with fixed interest payments.', // オプション: 短い説明
+      icon: 'https://example.org/jgb-icon.png', // 必須: アイコンのURL（HTTPS）
+      asset_class: 'rwa', // 必須: 資産クラス（Real World Assets）
+      asset_subclass: 'treasury', // asset_class='rwa'の場合は必須
+      issuer_name: 'Japan Treasury Co.', // 必須: 発行者名
+      urls: [
+        // オプション: 関連URLのリスト
+        {
+          url: 'https://japan-treasury.co/jgb10y',
+          type: 'website',
+          title: 'Product Page',
+        },
+        {
+          url: 'https://example-jgb10y.com/docs',
+          type: 'docs',
+          title: 'Bond Token Documentation',
+        },
+      ],
+      additional_info: {
+        // オプション: 追加情報（金利、満期日など）
+        interest_rate: '0.50%',
+        interest_type: 'fixed',
+        yield_source: 'Japanese Government Bonds',
+        maturity_date: '2034-03-20',
+        bond_code: 'JGB10Y-2034',
+        face_value: '1000000', // 額面100万円
+        payment_frequency: 'semi-annual',
+      },
+    });
+    const metadataHex = convertStringToHex(metadata);
+
+    // MPTokenIssuanceCreate トランザクションの準備
+    const tx: MPTokenIssuanceCreate = {
+      TransactionType: 'MPTokenIssuanceCreate',
+      Account: issuer.address, // 発行者アドレス
+      AssetScale: 0, // 小数点以下2桁 0=整数 1=小数点以下1桁 2=小数点以下2桁
+      MaximumAmount: '1000000000', // 最大供給量（オプション）
+      // TransferFee: 1000, // 転送手数料 1% (1000 / 100000 = 0.01)
+      MPTokenMetadata: metadataHex, // メタデータ（オプション）
+      Flags:
+        // | MPTokenIssuanceCreateFlags.tfMPTCanLock // ロック機能を有効にする
+        MPTokenIssuanceCreateFlags.tfMPTRequireAuth | // 認可必須（有効にした場合、mptokenAuthorizeByIssuer.ts で発行者による認可が必要）
+        // | MPTokenIssuanceCreateFlags.tfMPTCanEscrow // Escrow機能を有効にする
+        // | MPTokenIssuanceCreateFlags.tfMPTCanTrade // DEXでの取引機能を有効にする
+        // | MPTokenIssuanceCreateFlags.tfMPTCanTransfer // 第三者間の転送機能を有効にする
+        MPTokenIssuanceCreateFlags.tfMPTCanClawback, // Clawback機能を有効にする
+    };
+
+    // トランザクションの自動入力（手数料、シーケンス番号など）
+    const prepared = await client.autofill(tx);
+
+    // トランザクションに署名
+    const signed = issuer.sign(prepared);
+
+    // トランザクションを送信して結果を待機
+    const result = await client.submitAndWait(signed.tx_blob);
+
+    // トランザクション結果を確認（tesSUCCESS以外はエラーをスロー）
+    validateTransactionResult(result);
+
+    console.log('\n✅ MPToken発行が完了しました');
+
+    // MPTokenIssuanceIDを取得
+    if (
+      result.result.meta &&
+      typeof result.result.meta === 'object' &&
+      'mpt_issuance_id' in result.result.meta
+    ) {
+      console.log(
+        `\n🪙 MPTokenIssuanceID: ${result.result.meta.mpt_issuance_id}`,
+      );
+    } else if (result.result.meta && typeof result.result.meta === 'object') {
+      // メタデータからMPTokenIssuanceを探す
+      if (
+        'AffectedNodes' in result.result.meta &&
+        Array.isArray(result.result.meta.AffectedNodes)
+      ) {
+        for (const node of result.result.meta.AffectedNodes) {
+          if (
+            'CreatedNode' in node &&
+            node.CreatedNode.LedgerEntryType === 'MPTokenIssuance'
+          ) {
+            const newFields = node.CreatedNode.NewFields;
+            if (newFields && 'MPTokenIssuanceID' in newFields) {
+              console.log(
+                `\n🪙 MPTokenIssuanceID: ${newFields['MPTokenIssuanceID']}`,
+              );
+            }
+          }
+        }
+      }
+    }
+
+    // 環境変数にMPTokenIssuanceIDを設定するためのヒントを表示
+    console.log(
+      '💡 ヒント: 環境変数のMPT_ISSUANCE_IDにMPTokenIssuanceIDを設定してください',
+    );
+
+    // エクスプローラーで確認できるURLを表示
+    logExplorerUrl(result.result.hash);
+
+    return true;
+  } catch (error) {
+    console.error('❌ エラーが発生しました:', error);
+
+    // MPTokenIssuanceCreate特有のエラーメッセージの説明
+    if (error instanceof Error) {
+      if (error.message.includes('temMALFORMED')) {
+        console.error('💡 ヒント: トランザクションが正しく指定されていません');
+      } else if (
+        error.message.includes(
+          'TransferFee cannot be provided without enabling tfMPTCanTransfer',
+        )
+      ) {
+        console.error(
+          '💡 ヒント: TransferFeeを設定するには、tfMPTCanTransferフラグを有効にする必要があります',
+        );
+      } else if (error.message.includes('temBAD_MPTOKEN_TRANSFER_FEE')) {
+        console.error(
+          '💡 ヒント: TransferFeeが許容範囲外です（0-50000の範囲で指定してください）',
+        );
+      } else if (error.message.includes('temBAD_MPTOKEN_ASSET_SCALE')) {
+        console.error(
+          '💡 ヒント: AssetScaleが許容範囲外です（0-19の範囲で指定してください）',
+        );
+      } else if (error.message.includes('tecINSUFFICIENT_RESERVE')) {
+        console.error(
+          '💡 ヒント: トークン発行後にアカウントの準備金要件を満たせません',
+        );
+      } else if (error.message.includes('tecDUPLICATE')) {
+        console.error('💡 ヒント: 同じ設定のMPTokenIssuanceが既に存在します');
+      }
+    }
+
+    return false;
+  } finally {
+    // 接続を終了
+    await client.disconnect();
+  }
+}
+
+// スクリプトが直接実行された場合の処理
+if (import.meta.url === `file://${process.argv[1]}`) {
+  mptokenIssuanceCreate().then((success) => {
+    if (!success) {
+      process.exit(1);
+    }
+  });
+}

--- a/src/xrpl/MPTokens/mptokenIssuanceDestroy.ts
+++ b/src/xrpl/MPTokens/mptokenIssuanceDestroy.ts
@@ -1,0 +1,129 @@
+import { Client, type MPTokenIssuanceDestroy, Wallet } from 'xrpl';
+import { env } from '../../config/env';
+import { getNetworkUrl } from '../../config/network';
+import { logExplorerUrl } from '../../lib/logger';
+import { validateTransactionResult } from '../../lib/validateTransaction';
+
+export async function mptokenIssuanceDestroy(): Promise<boolean> {
+  // ネットワーク設定
+  const network = getNetworkUrl();
+  const client = new Client(network.ws);
+
+  try {
+    // ウォレット作成（発行者）
+    const issuer = Wallet.fromSeed(env.ISUEER_SEED);
+
+    // XRPLネットワークに接続
+    await client.connect();
+
+    console.log('🗑️  MPTokenを破棄します...');
+    console.log(`発行者アドレス: ${issuer.address}`);
+
+    // 環境変数からMPTokenIssuanceIDを取得
+    const mptIssuanceID = env.MPT_ISSUANCE_ID || '';
+
+    if (!mptIssuanceID) {
+      console.error('\n❌ MPTokenIssuanceIDが設定されていません');
+      console.error(
+        '💡 ヒント: mptokenIssuanceCreate.ts を実行して取得したMPTokenIssuanceIDを設定してください',
+      );
+      return false;
+    }
+
+    // MPTokenIssuanceの状態を確認
+    console.log('\n📊 破棄前のMPTokenIssuance情報を確認...');
+    try {
+      const issuanceInfo = await client.request({
+        command: 'ledger_entry',
+        mpt_issuance: mptIssuanceID,
+        ledger_index: 'validated',
+      });
+      console.log(JSON.stringify(issuanceInfo.result, null, 2));
+
+      // 保有者が存在するかチェック
+      const resultNode = issuanceInfo.result;
+      if (resultNode.node && 'OutstandingAmount' in resultNode.node) {
+        const outstandingAmount = resultNode.node.OutstandingAmount;
+        if (outstandingAmount && outstandingAmount !== '0') {
+          console.warn(
+            '\n⚠️  警告: まだ保有者が存在します。破棄するには全ての保有者が保有していない状態にする必要があります',
+          );
+          console.warn(`   Outstanding Amount: ${outstandingAmount}`);
+        }
+      }
+    } catch (entryError) {
+      console.log('⚠️  MPTokenIssuance情報取得に失敗しました:', entryError);
+    }
+
+    // MPTokenIssuanceDestroy トランザクションの準備
+    const tx: MPTokenIssuanceDestroy = {
+      TransactionType: 'MPTokenIssuanceDestroy',
+      Account: issuer.address, // 発行者アドレス
+      MPTokenIssuanceID: mptIssuanceID, // 破棄するMPTokenIssuanceID
+    };
+
+    // トランザクションの自動入力（手数料、シーケンス番号など）
+    const prepared = await client.autofill(tx);
+
+    // トランザクションに署名
+    const signed = issuer.sign(prepared);
+
+    // トランザクションを送信して結果を待機
+    const result = await client.submitAndWait(signed.tx_blob);
+
+    // トランザクション結果を確認（tesSUCCESS以外はエラーをスロー）
+    validateTransactionResult(result);
+
+    console.log('\n✅ MPToken破棄が完了しました');
+
+    console.log('\n📊 破棄情報:');
+    console.log(`  - MPTokenIssuanceID: ${mptIssuanceID}`);
+    console.log(`  - 発行者: ${issuer.address}`);
+
+    // エクスプローラーで確認できるURLを表示
+    logExplorerUrl(result.result.hash);
+
+    return true;
+  } catch (error) {
+    console.error('❌ エラーが発生しました:', error);
+
+    // MPTokenIssuanceDestroy特有のエラーメッセージの説明
+    if (error instanceof Error) {
+      if (error.message.includes('tecHAS_OBLIGATIONS')) {
+        console.error(
+          '💡 ヒント: まだ保有者が存在します。破棄するには全ての保有者が保有していない状態にする必要があります',
+        );
+        console.error('   - 全ての保有者からトークンをClawbackする');
+        console.error('   - または保有者にトークンを返還してもらう');
+      } else if (error.message.includes('tecNO_PERMISSION')) {
+        console.error(
+          '💡 ヒント: 破棄権限がありません（発行者のみが破棄できます）',
+        );
+      } else if (error.message.includes('tecNO_ENTRY')) {
+        console.error('💡 ヒント: 指定されたMPTokenIssuanceIDが存在しません');
+      } else if (error.message.includes('temMALFORMED')) {
+        console.error('💡 ヒント: トランザクションが正しく指定されていません');
+      } else if (error.message.includes('temDISABLED')) {
+        console.error('💡 ヒント: MPTokensV1 Amendmentが有効ではありません');
+      } else if (error.message.includes('tecINSUFFICIENT_RESERVE')) {
+        console.error(
+          '💡 ヒント: トランザクション実行後にアカウントの準備金要件を満たせません',
+        );
+      }
+    }
+
+    return false;
+  } finally {
+    // 接続を終了
+    await client.disconnect();
+  }
+}
+
+// スクリプトが直接実行された場合の処理
+if (import.meta.url === `file://${process.argv[1]}`) {
+  mptokenIssuanceDestroy().then((success) => {
+    if (!success) {
+      process.exit(1);
+    }
+  });
+}

--- a/src/xrpl/MPTokens/mptokenPayment.ts
+++ b/src/xrpl/MPTokens/mptokenPayment.ts
@@ -1,0 +1,137 @@
+import { Client, type Payment, Wallet } from 'xrpl';
+import { env } from '../../config/env';
+import { getNetworkUrl } from '../../config/network';
+import { logExplorerUrl } from '../../lib/logger';
+import { validateTransactionResult } from '../../lib/validateTransaction';
+
+export async function mptokenPayment(): Promise<boolean> {
+  // ネットワーク設定
+  const network = getNetworkUrl();
+  const client = new Client(network.ws);
+
+  try {
+    // ウォレット作成
+    const issuer = Wallet.fromSeed(env.ISUEER_SEED);
+    const user = Wallet.fromSeed(env.USER_SEED);
+
+    // XRPLネットワークに接続
+    await client.connect();
+
+    console.log('💸 MPTokenを送金します...');
+    console.log(`送信者アドレス: ${issuer.address}`);
+    console.log(`受信者アドレス: ${user.address}`);
+
+    // 環境変数からMPTokenIssuanceIDを取得
+    const mptIssuanceID = env.MPT_ISSUANCE_ID || '';
+
+    if (!mptIssuanceID) {
+      console.error('\n❌ MPTokenIssuanceIDが設定されていません');
+      console.error(
+        '💡 ヒント: mptokenIssuanceCreate.ts を実行して取得したMPTokenIssuanceIDを設定してください',
+      );
+      return false;
+    }
+
+    // MPToken送金トランザクションの準備
+    const tx: Payment = {
+      TransactionType: 'Payment',
+      Account: issuer.address, // 送信者アドレス
+      Destination: user.address, // 受信者アドレス
+      Amount: {
+        mpt_issuance_id: mptIssuanceID, // MPTのIssuanceID
+        value: '100', // 送金量
+      },
+    };
+
+    // トランザクションの自動入力（手数料、シーケンス番号など）
+    const prepared = await client.autofill(tx);
+
+    // トランザクションに署名
+    const signed = issuer.sign(prepared);
+
+    // トランザクションを送信して結果を待機
+    const result = await client.submitAndWait(signed.tx_blob);
+
+    // トランザクション結果を確認（tesSUCCESS以外はエラーをスロー）
+    validateTransactionResult(result);
+
+    console.log('\n✅ MPToken送金が完了しました');
+
+    // 残高確認
+    try {
+      const receiverBalance = await client.request({
+        command: 'account_objects',
+        account: user.address,
+        ledger_index: 'validated',
+      });
+      console.log('\n💰 受信者のMPToken残高:');
+      if ('account_objects' in receiverBalance.result) {
+        const mptBalances = receiverBalance.result.account_objects.filter(
+          (obj) => {
+            const ledgerObj = obj as {
+              LedgerEntryType: string;
+              MPTokenIssuanceID?: string;
+            };
+            return (
+              ledgerObj.LedgerEntryType === 'MPToken' &&
+              ledgerObj.MPTokenIssuanceID === mptIssuanceID
+            );
+          },
+        );
+        if (mptBalances.length > 0) {
+          const mptBalance = mptBalances[0] as unknown as {
+            MPTokenIssuanceID: string;
+            MPTAmount: string;
+          };
+          console.log(`  - MPTokenIssuanceID: ${mptBalance.MPTokenIssuanceID}`);
+          console.log(`    残高: ${mptBalance.MPTAmount}`);
+        } else {
+          console.log('  - 該当するMPToken残高がありません');
+        }
+      }
+    } catch (balanceError) {
+      console.log('\n⚠️  残高取得に失敗しました:', balanceError);
+    }
+
+    // エクスプローラーで確認できるURLを表示
+    logExplorerUrl(result.result.hash);
+
+    return true;
+  } catch (error) {
+    console.error('❌ エラーが発生しました:', error);
+
+    // Payment（MPToken）特有のエラーメッセージの説明
+    if (error instanceof Error) {
+      if (error.message.includes('tecNO_AUTH')) {
+        console.error('💡 ヒント: 受信者がMPTokenの保有を認可されていません');
+        console.error(
+          '   mptokenAuthorizeByUser.ts または mptokenAuthorizeByIssuer.ts を実行して認可してください',
+        );
+      } else if (error.message.includes('tecNO_ENTRY')) {
+        console.error('💡 ヒント: 指定されたMPTokenIssuanceIDが存在しません');
+      } else if (error.message.includes('tecINSUFFICIENT_RESERVE')) {
+        console.error(
+          '💡 ヒント: トランザクション実行後にアカウントの準備金要件を満たせません',
+        );
+      } else if (error.message.includes('temMALFORMED')) {
+        console.error('💡 ヒント: トランザクションが正しく指定されていません');
+      } else if (error.message.includes('tecOBJECT_NOT_FOUND')) {
+        console.error('💡 ヒント: 指定されたMPTokenIssuanceIDが存在しません');
+      }
+    }
+
+    return false;
+  } finally {
+    // 接続を終了
+    await client.disconnect();
+  }
+}
+
+// スクリプトが直接実行された場合の処理
+if (import.meta.url === `file://${process.argv[1]}`) {
+  mptokenPayment().then((success) => {
+    if (!success) {
+      process.exit(1);
+    }
+  });
+}


### PR DESCRIPTION
# MPT (Multi-Purpose Tokens) ファイル一覧

## 📂 実行スクリプト（6ファイル）

### 1. `mptokenIssuanceCreate.ts`
- **機能**: MPTの発行
- **トランザクション**: `MPTokenIssuanceCreate`
- **説明**: メタデータ、最大供給量、転送手数料、各種フラグを設定
- **実行後**: MPTokenIssuanceIDを取得して環境変数に設定
- **必須**: ✅

### 2. `mptokenAuthorizeByUser.ts`
- **機能**: ユーザー自身がMPTの保有を承認
- **トランザクション**: `MPTokenAuthorize`
- **説明**: 全てのMPTで必須のステップ
- **実行タイミング**: ユーザーがMPTを受け取る前に実行
- **必須**: ✅

### 3. `mptokenAuthorizeByIssuer.ts`
- **機能**: 発行者がユーザーを認可
- **トランザクション**: `MPTokenAuthorize`
- **説明**: `tfMPTRequireAuth`フラグ有効時のみ必要
- **実行タイミング**: ユーザー承認後に発行者が実行
- **必須**: 条件付き（RequireAuth時のみ）

### 4. `mptokenPayment.ts`
- **機能**: MPTの送金
- **トランザクション**: `Payment`
- **説明**: 指定した数量を受信者に送金
- **追加機能**: 送金後、受信者のMPT残高を表示
- **必須**: 任意

### 5. `mptokenClawback.ts`
- **機能**: 発行者がMPTを取り戻す
- **トランザクション**: `Clawback`
- **説明**: `tfMPTCanClawback`フラグ有効時のみ実行可能
- **追加機能**: Clawback前後の残高を表示
- **必須**: 任意

### 6. `mptokenIssuanceDestroy.ts`
- **機能**: MPTの破棄
- **トランザクション**: `MPTokenIssuanceDestroy`
- **説明**: 全保有者が保有していない状態（OutstandingAmount = 0）が前提
- **追加機能**: 破棄前のMPTokenIssuance情報を確認
- **必須**: 任意

## 📚 ドキュメント（1ファイル）

### 7. `README.md`
- **機能**: MPTの総合ドキュメント
- **内容**: 
  - MPTの特徴、実行方法、パラメータ説明
  - XLS-89d標準のメタデータ例（国債トークン）
  - フラグの詳細説明と注意事項

---

## 🔄 標準実行フロー

```mermaid
graph TD
    A[mptokenIssuanceCreate.ts] --> B[mptokenAuthorizeByUser.ts]
    B --> C{RequireAuth?}
    C -->|Yes| D[mptokenAuthorizeByIssuer.ts]
    C -->|No| E[mptokenPayment.ts]
    D --> E
    E --> F[mptokenClawback.ts]
    F --> G[mptokenIssuanceDestroy.ts]
```

## 📋 実行順序

1. **`mptokenIssuanceCreate.ts`** → MPT発行
2. **`mptokenAuthorizeByUser.ts`** → ユーザー承認
3. **`mptokenAuthorizeByIssuer.ts`** → 発行者認可（RequireAuth時のみ）
4. **`mptokenPayment.ts`** → MPT送金
5. **`mptokenClawback.ts`** → MPT取り戻し（任意）
6. **`mptokenIssuanceDestroy.ts`** → MPT破棄（任意）

---

## 🎯 機能マトリックス

| ファイル | トランザクション | 主な機能 | 必須/任意 | 前提条件 |
|---------|-----------------|---------|----------|----------|
| `mptokenIssuanceCreate.ts` | MPTokenIssuanceCreate | MPT発行、メタデータ設定 | 必須 | - |
| `mptokenAuthorizeByUser.ts` | MPTokenAuthorize | ユーザーが保有を承認 | 必須 | MPT発行済み |
| `mptokenAuthorizeByIssuer.ts` | MPTokenAuthorize | 発行者がユーザーを認可 | 条件付き | RequireAuth有効 |
| `mptokenPayment.ts` | Payment | MPT送金、残高確認 | 任意 | 認可完了 |
| `mptokenClawback.ts` | Clawback | MPT取り戻し、残高確認 | 任意 | Clawback有効 |
| `mptokenIssuanceDestroy.ts` | MPTokenIssuanceDestroy | MPT破棄、情報確認 | 任意 | OutstandingAm